### PR TITLE
fix proptype number

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -144,15 +144,14 @@ function normalizeChildren(children : NullableChildrenType) : $ReadOnlyArray<Ele
     for (const child of children) {
         if (!child) {
             continue;
-        } else if (typeof child === 'string') {
-            result.push(new TextNode(child));
+        } else if (typeof child === 'string' || typeof child === 'number') {
+            result.push(new TextNode(`${ child }`));
         } else if (Array.isArray(child)) {
             for (const subchild of normalizeChildren(child)) {
                 result.push(subchild);
             }
         } else if (child && (child.type === NODE_TYPE.ELEMENT || child.type === NODE_TYPE.TEXT || child.type === NODE_TYPE.COMPONENT)) {
             result.push(child);
-    
         } else {
             throw new TypeError(`Unrecognized node type: ${ typeof child }`);
         }


### PR DESCRIPTION
Following the reported issue #7 and your comment in https://github.com/krakenjs/jsx-pragmatic/pull/8 I created another pull request to fix it.

```
(`${ child }`)
```
is as well necessary, else number is not converted to string.