### PR TITLE
transform renderer

### DIFF
--- a/src/renderers/dom.js
+++ b/src/renderers/dom.js
@@ -157,11 +157,11 @@ function addChildren(el : HTMLElement, node : ElementNode, doc : Document, rende
 }
 
 export function dom(opts? : { doc? : Document, transform?: (node: any) => any } = {}) : DomRenderer {
-    const { doc = document } = opts;
+    const { doc = document, transform } = opts;
     
     const domRenderer : DomRenderer = (node) => {
-        if (opts && opts.transform) {
-            node = opts.transform(node);
+        if (transform) {
+            node = transform(node);
         }
 
         if (node.type === NODE_TYPE.COMPONENT) {

--- a/src/renderers/dom.js
+++ b/src/renderers/dom.js
@@ -156,10 +156,14 @@ function addChildren(el : HTMLElement, node : ElementNode, doc : Document, rende
     }
 }
 
-export function dom(opts? : { doc? : Document } = {}) : DomRenderer {
+export function dom(opts? : { doc? : Document, transform?: (node: any) => any } = {}) : DomRenderer {
     const { doc = document } = opts;
     
     const domRenderer : DomRenderer = (node) => {
+        if (opts && opts.transform) {
+            node = opts.transform(node);
+        }
+
         if (node.type === NODE_TYPE.COMPONENT) {
             return node.renderComponent(domRenderer);
         }

--- a/src/renderers/html.js
+++ b/src/renderers/html.js
@@ -65,10 +65,11 @@ function propsToHTML(props : NodePropsType) : string {
 }
 
 export function html(opts? : { transform?: (node: any) => any } = {}) : HTMLRenderer {
+    const { transform } = opts;
 
     const htmlRenderer = (node) => {
-        if (opts && opts.transform) {
-            node = opts.transform(node);
+        if (transform) {
+            node = transform(node);
         }
 
         if (node.type === NODE_TYPE.COMPONENT) {

--- a/src/renderers/html.js
+++ b/src/renderers/html.js
@@ -64,9 +64,13 @@ function propsToHTML(props : NodePropsType) : string {
     return ` ${ pairs.join(' ') }`;
 }
 
-export function html() : HTMLRenderer {
+export function html(opts? : { transform?: (node: any) => any } = {}) : HTMLRenderer {
 
     const htmlRenderer = (node) => {
+        if (opts && opts.transform) {
+            node = opts.transform(node);
+        }
+
         if (node.type === NODE_TYPE.COMPONENT) {
             return [].concat(node.renderComponent(htmlRenderer)).join('');
         }

--- a/src/renderers/preact.js
+++ b/src/renderers/preact.js
@@ -24,12 +24,16 @@ function mapPreactProps(props : NodePropsType) : NodePropsType {
     };
 }
 
-export function preact({ Preact } : { Preact : PreactType } = {}) : PreactRenderer {
+export function preact({ Preact, transform } : { Preact : PreactType, transform?: (node: any) => any } = {}) : PreactRenderer {
     if (!Preact) {
         throw new Error(`Must pass Preact library to react renderer`);
     }
     
     const reactRenderer = (node) => {
+        if (transform) {
+            node = transform(node);
+        }
+
         if (node.type === NODE_TYPE.COMPONENT) {
             return Preact.h(() => (node.renderComponent(reactRenderer) || null), node.props, ...node.renderChildren(reactRenderer));
         }

--- a/src/renderers/react.js
+++ b/src/renderers/react.js
@@ -25,12 +25,16 @@ function mapReactProps(props : NodePropsType) : NodePropsType {
     };
 }
 
-export function react({ React } : { React : ReactType } = {}) : ReactRenderer {
+export function react({ React, transform } : { React : ReactType, transform?: (node: any) => any } = {}) : ReactRenderer {
     if (!React) {
         throw new Error(`Must pass React library to react renderer`);
     }
     
     const reactRenderer = (node) => {
+        if (transform) {
+            node = transform(node);
+        }
+
         if (node.type === NODE_TYPE.COMPONENT) {
             return React.createElement(() => (node.renderComponent(reactRenderer) || null), node.props, ...node.renderChildren(reactRenderer));
         }


### PR DESCRIPTION
Right now, it's not possible to re-use default renderer: html, dom, react and preact. So if I want to change a single node but still output as html, I have to use my own renderer like described here https://github.com/krakenjs/jsx-pragmatic#write-your-own-renderer and re-copy all the content of `/src/renderers/html.js`.

In order to be able to re-use the renderer, I introduce a `transform` params for each of your default renderers. So now I can do something like:

```
    const source = mycomponent(props)render(
        html({
            transform: node => {
                console.log('node', node);
                // if node equal something
                // then return something different
                // else return node
                return node;
            },
        }),
    );
```