### PR TITLE
Typo in example code "Write your own renderer"

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ function customDom({ removeScriptTags = false } = {}) {
     }
 
     if (node.type === NODE_TYPE.ELEMENT) {
-      if (removeScriptTags && name === 'script') {
+      if (removeScriptTags && node.name === 'script') {
         return;
       }
 


### PR DESCRIPTION
Replaced `name` variable with `node.name` in `customDom` example code.