### PR TITLE
fix creation of svg elements

### DIFF
--- a/src/renderers/dom.js
+++ b/src/renderers/dom.js
@@ -164,6 +164,17 @@ const getDefaultDomOptions = () : DomOptions => {
     return {};
 };
 
+function addXmlNamespace(node: ElementNode) {
+    if (typeof node.props.xmlns !== 'string') {
+        node.props.xmlns = 'http://www.w3.org/2000/svg'
+    }
+    node.children.map((child) => {
+        child.props.xmlns = node.props.xmlns;
+        child.children.map(setXmlNs)
+        return child;
+    });
+}
+
 export function dom(opts? : DomOptions = getDefaultDomOptions()) : DomRenderer {
     const { doc = document } = opts;
     
@@ -178,14 +189,11 @@ export function dom(opts? : DomOptions = getDefaultDomOptions()) : DomRenderer {
         }
         
         if (node.type === NODE_TYPE.ELEMENT) {
+            if (typeof node.name === 'svg') {
+                addXmlNamespace(node)
+            }
             const el = createElement(doc, node);
             addProps(el, node);
-            if (typeof node.props.xmlns === 'string') {
-                node.children.map((child) => {
-                    child.props.xmlns = node.props.xmlns;
-                    return child;
-                });
-            }
             addChildren(el, node, doc, domRenderer);
             // $FlowFixMe
             return el;

--- a/src/renderers/dom.js
+++ b/src/renderers/dom.js
@@ -39,6 +39,8 @@ function fixScripts(el : HTMLElement, doc : Document = window.document) {
 function createElement(doc : Document, node : ElementNode) : HTMLElement {
     if (node.props[ELEMENT_PROP.EL]) {
         return node.props[ELEMENT_PROP.EL];
+    } else if (typeof node.props.xmlns === 'string') {
+        return doc.createElementNS(node.props.xmlns, node.name);
     }
 
     return doc.createElement(node.name);
@@ -178,6 +180,12 @@ export function dom(opts? : DomOptions = getDefaultDomOptions()) : DomRenderer {
         if (node.type === NODE_TYPE.ELEMENT) {
             const el = createElement(doc, node);
             addProps(el, node);
+            if (typeof node.props.xmlns === 'string') {
+                node.children.map((child) => {
+                    child.props.xmlns = node.props.xmlns;
+                    return child;
+                });
+            }
             addChildren(el, node, doc, domRenderer);
             // $FlowFixMe
             return el;


### PR DESCRIPTION
SVG elements and their children need to be created with [createElementNS](https://developer.mozilla.org/en-US/docs/Web/API/Document/createElementNS) instead of [createElement](https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement) in order to render appropriately. Passing an svg in currently creates an [HTMLUnknownElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLUnknownElement) node, that is then has a computed width and height of zero. 

```javascript
document.createElement('svg').constructor.name === 'HTMLUnknownElement'
document.createElementNS('http://www.w3.org/2000/svg', 'svg').constructor.name === 'SVGSVGElement'
```

[SVGSVGElement](https://developer.mozilla.org/en-US/docs/Web/API/SVGSVGElement) is an interface to for svg elements.


