### PR TITLE
fix(iframe): add empty srcdoc attribute to iframe elem if not exist

### DIFF
--- a/src/renderers/dom.js
+++ b/src/renderers/dom.js
@@ -122,8 +122,12 @@ function addProps(el: HTMLElement | Element, node) {
   // If the element is an iframe and it has no srcdoc or src, set the srcdoc to an empty string.
   // Content specified via srcdoc is treated as being from the same origin as the parent document.
   // In some browsers (like Safari 17+), empty iframes without src or srcdoc may be treated as "anonymous," potentially blocking certain content.
-  if (el.tagName.toLowerCase() === ELEMENT_TAG.IFRAME && (!props.srcdoc && !props.src)) {
-    el.setAttribute('srcdoc', '');
+  if (
+    el.tagName.toLowerCase() === ELEMENT_TAG.IFRAME &&
+    !props.srcdoc &&
+    !props.src
+  ) {
+    el.setAttribute("srcdoc", "");
   }
 }
 const ADD_CHILDREN: {

--- a/src/renderers/dom.js
+++ b/src/renderers/dom.js
@@ -118,6 +118,13 @@ function addProps(el: HTMLElement | Element, node) {
   if (el.tagName.toLowerCase() === ELEMENT_TAG.IFRAME && !props.id) {
     el.setAttribute(ELEMENT_PROP.ID, `jsx-iframe-${uniqueID()}`);
   }
+
+  // If the element is an iframe and it has no srcdoc or src, set the srcdoc to an empty string.
+  // Content specified via srcdoc is treated as being from the same origin as the parent document.
+  // In some browsers (like Safari 17+), empty iframes without src or srcdoc may be treated as "anonymous," potentially blocking certain content.
+  if (el.tagName.toLowerCase() === ELEMENT_TAG.IFRAME && (!props.srcdoc && !props.src)) {
+    el.setAttribute('srcdoc', '');
+  }
 }
 const ADD_CHILDREN: {
   [string]: (HTMLElement | Element, ElementNode, DomNodeRenderer) => void,


### PR DESCRIPTION
This PR fixes an issue with embedding iframe elements via jsx-pragmatic that do not specify a `src` or `srcdoc` property. This issue manifests itself while using zoid to render a cross-origin iframe within an "anonymous" iframe on Safari >=17.